### PR TITLE
Fix/issue25: 이미지 업로드 시 발생하는 에러 및 중복 코드 제거

### DIFF
--- a/Backend/src/main/java/dsko/hier/fortune/face/presentation/ImageController.java
+++ b/Backend/src/main/java/dsko/hier/fortune/face/presentation/ImageController.java
@@ -19,7 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
         description = "이미지 관련 API"
 )
 @RestController
-@RequestMapping("/api/face/picture")
+@RequestMapping("/api/fortune/face/picture")
 @RequiredArgsConstructor
 public class ImageController {
 
@@ -28,13 +28,13 @@ public class ImageController {
     @PostMapping
     public APIResponse<Map<String, String>> getPresignedUrl(
             @Validated @RequestBody ImageRequest request) {
-        return APIResponse.success(imageService.getPresignedUrl("image", request));
+        return APIResponse.success(imageService.getPresignedUrlForSimple(request));
     }
 
     @PostMapping("/multi")
     public APIResponse<Map<String, String>> getPresignedUrl(
             @Validated @RequestBody MultiImageRequest request) {
-        return APIResponse.success(imageService.getPresignedUrl("images", request));
+        return APIResponse.success(imageService.getPresignedUrlForMultiple(request));
     }
 
     @PostMapping("/delete")


### PR DESCRIPTION
# 🛠️ Related Issue / 관련 이슈

fixes #25 

---

# 📂 PR Type / PR 유형

- [x] Bugfix (버그 수정)
- [ ] Feature (새 기능 추가)
- [ ] Test (테스트)
- [ ] Refactor (리팩터링)
- [ ] Documentation (문서 수정)
- [ ] Other (기타)

# ✏️ Brief Description / 간단 설명

- 해당 문제는 서버의 로직이 아닌 요청 방식의 문제로 파악이 되었습니다.
- 기존에는 PresignedUrl 을 받은 이후 해당 주소로 PUT 방식으로 요청을 보낼 때 다음과 같은 방법으로 포스트맨에서 요청을 보냈습니다.   
    - form-data 방식으로 요청
<img width="1480" height="276" alt="스크린샷 2025-09-24 22 00 20" src="https://github.com/user-attachments/assets/ecf9e426-3e12-4dee-8fec-c0d76b38d8e2" />


해당 방식은 AWS 에 고유한 값으로 잘 저장이 되지만 인코딩이 깨져 저장할 가치가 없는 데이터가 되는 문제가 발생했습니다.

이러한 문제가 발생한 이유는 해당 방식을 사용하면 Content-Type: multipart/form-data 헤더를 사용하며, 파일 데이터와 함께 파일 이름, 타입 등 다양한 정보를 함께 묶어서 전송하기 때문입니다.


이 부분에서 서버에서 PresignedUrl로 사전에 지정한 Content-Type과 실제 데이터가 s3에서 일치하지 않는 문제가 발생하게 됩니다.


이 문제는 포스트맨 사용 시 form/data 가 아닌 binary 사용 시 간단하게 해결할 수 있습니다!

<img width="1513" height="251" alt="스크린샷 2025-09-24 22 07 05" src="https://github.com/user-attachments/assets/ae314c1a-bbb5-49bb-b675-aacb3f58482a" />


참고 : https://stackoverflow.com/questions/58234437/corrupted-image-on-uploading-image-to-aws-s3-via-signed-url

---
